### PR TITLE
mbi2: Fix length of old ACPI tables

### DIFF
--- a/standalone/mbi2.c
+++ b/standalone/mbi2.c
@@ -147,7 +147,7 @@ void mbi2_add_mbi1_memmap(struct mbi2_builder *bld,
 
 void mbi2_add_rsdp(struct mbi2_builder *bld, const struct rsdp *rsdp) {
   /* We have to account for the final NUL byte. */
-  size_t rsdp_len = rsdp->rev == 1 ? 20 : rsdp->size;
+  size_t rsdp_len = rsdp->rev <= 1 ? 20 : rsdp->size;
 
   struct mbi2_tag tag = {
       .type = rsdp->rev == 1 ? MBI2_TAG_RSDP_V1 : MBI2_TAG_RSDP_V2,


### PR DESCRIPTION
I've seen issues with running Multiboot2 kernels with bender in qemu 8.0 and traced them back to an empty RSDP table in the MBI2.

According to
https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#root-system-description-pointer-rsdp-structure, the revision field is zero for ACPI 1.0:

> The revision of this structure. Larger revision numbers are backward
> compatible to lower revision numbers. The ACPI version 1.0 revision
> number of this table is zero. The ACPI version 1.0 RSDP Structure only
> includes the first 20 bytes of this table, bytes 0 to 19. It does not
> include the Length field and beyond. The current value for this field is
> 2.